### PR TITLE
Force absolute sourcemap urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ dist
 .tern-port
 
 results.pdf
+screenshots/
+.vscode/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"dist/"
 	],
 	"dependencies": {
-		"chokidar": "^3.4.3"
+		"chokidar": "^3.4.3",
+		"karma-sourcemap-loader": "^0.3.8"
 	},
 	"peerDependencies": {
 		"esbuild": "0.8.x"
@@ -42,7 +43,7 @@
 		"kolorist": "^1.2.8",
 		"lint-staged": "^10.5.3",
 		"mocha": "^8.2.1",
-		"pentf": "^1.7.0",
+		"pentf": "^1.8.2",
 		"prettier": "^2.2.1",
 		"puppeteer": "^5.5.0",
 		"rimraf": "^3.0.2",

--- a/test/base.karma.conf.js
+++ b/test/base.karma.conf.js
@@ -1,22 +1,40 @@
+const localLaunchers = {
+	ChromeCustom: {
+		base: "Chrome",
+		flags: [
+			// See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+			"--headless",
+			"--disable-gpu",
+			"--no-gpu",
+			// Without a remote debugging port, Google Chrome exits immediately.
+			"--remote-debugging-port=9333",
+		],
+	},
+};
+
 module.exports = {
 	baseConfig: {
 		plugins: [
 			"karma-mocha",
 			"karma-mocha-reporter",
 			"karma-chrome-launcher",
+			"karma-sourcemap-loader",
 			require("../src/index"),
 		],
 
+		browsers: Object.keys(localLaunchers),
+		customLaunchers: localLaunchers,
+
 		frameworks: ["mocha"],
 		reporters: ["mocha"],
-		browsers: ["ChromeHeadless"],
+		browsers: ["ChromeCustom"],
 
 		basePath: "",
-		files: [{ pattern: "files/main-*.js", watched: false }],
+		files: [{ pattern: "files/**/*main-*.js", watched: false }],
 		exclude: [],
 
 		preprocessors: {
-			"**/*.js": ["esbuild"],
+			"files/**/*.js": ["esbuild"],
 		},
 	},
 };

--- a/test/fixtures/sourcemap/files/dep1.js
+++ b/test/fixtures/sourcemap/files/dep1.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 42;
+}

--- a/test/fixtures/sourcemap/files/main-a.js
+++ b/test/fixtures/sourcemap/files/main-a.js
@@ -1,0 +1,7 @@
+import { foo } from "./dep1";
+
+describe("simple", () => {
+	it("should work", () => {
+		return foo();
+	});
+});

--- a/test/fixtures/sourcemap/files/sub/dep2.js
+++ b/test/fixtures/sourcemap/files/sub/dep2.js
@@ -1,0 +1,3 @@
+export function bar(a, b) {
+	return a + b;
+}

--- a/test/fixtures/sourcemap/files/sub/main-b.js
+++ b/test/fixtures/sourcemap/files/sub/main-b.js
@@ -1,0 +1,7 @@
+import { bar } from "./dep2";
+
+describe("simple", () => {
+	it("should work", () => {
+		return bar();
+	});
+});

--- a/test/fixtures/sourcemap/karma.conf.js
+++ b/test/fixtures/sourcemap/karma.conf.js
@@ -1,0 +1,10 @@
+const { baseConfig } = require("../../base.karma.conf");
+
+module.exports = function (config) {
+	config.set({
+		...baseConfig,
+		preprocessors: {
+			"**/*.js": ["esbuild", "sourcemap"],
+		},
+	});
+};

--- a/test/sourcemap.test.ts
+++ b/test/sourcemap.test.ts
@@ -1,0 +1,49 @@
+import { runKarma } from "./test-utils";
+import { assertEventually } from "pentf/assert_utils";
+import { newPage } from "pentf/browser_utils";
+import path from "path";
+import { strict as assert } from "assert";
+import { SourceMapPayload } from "module";
+
+export const description = "Resolve source maps relative to an absolute root";
+export async function run(config: any) {
+	const { output } = await runKarma(config, "sourcemap");
+
+	await assertEventually(() => {
+		return output.stdout.find(line => /2 tests completed/.test(line));
+	});
+
+	const match = output.stdout
+		.join("\n")
+		.match(/open (https?:\/\/localhost:\d{4})\//);
+	if (!match || match.length < 1) {
+		throw new Error("Unable to find server address");
+	}
+
+	const address = match[1];
+
+	const page = await newPage(config);
+	await page.goto(`${address}/debug.html`);
+
+	const js = await page.evaluate(() => {
+		return fetch("/base/files/sub/main-b.js").then(res => res.text());
+	});
+
+	const m = js.match(/\/\/# sourceMappingURL=(.*)$/);
+	if (!m || m.length < 1) {
+		throw new Error("Unable to find source map url");
+	}
+
+	assert.equal(m[1], "/base/files/sub/main-b.js.map");
+
+	const mapText = await page.evaluate(() => {
+		return fetch("/base/files/sub/main-b.js.map").then(res => res.text());
+	});
+
+	const map = JSON.parse(mapText) as SourceMapPayload;
+
+	assert.deepStrictEqual(map.sources, [
+		path.join(process.cwd(), "/test/fixtures/sourcemap/files/sub/dep2.js"),
+		path.join(process.cwd(), "/test/fixtures/sourcemap/files/sub/main-b.js"),
+	]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axe-core@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
+  integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -1359,6 +1364,13 @@ karma-mocha@^2.0.1:
   dependencies:
     minimist "^1.2.3"
 
+karma-sourcemap-loader@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.8.tgz#d4bae72fb7a8397328a62b75013d2df937bdcf9c"
+  integrity sha512-zorxyAakYZuBcHRJE+vbrK2o2JXLFWK8VVjiT/6P+ltLBUGUvqTEkUiQ119MGdOrK7mrmxXHZF1/pfT6GgIZ6g==
+  dependencies:
+    graceful-fs "^4.1.2"
+
 karma@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/karma/-/karma-5.2.3.tgz#3264024219bad2728e92542e0058a2492d7a46e4"
@@ -1837,15 +1849,16 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-pentf@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/pentf/-/pentf-1.7.0.tgz#8b592f6044b09bf0c047637257ec0e9c70dc1558"
-  integrity sha512-T0zmOSs2No+o8qMN40PrmIbeBIn0p5tuA4DTaUwHAE0Qe9cmGcjp1D5yViptsGUQ+LvOErJ0kU/H4QtZjB3maw==
+pentf@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/pentf/-/pentf-1.8.2.tgz#e3e0b1d7c1953e09636805cf251bff20890365ad"
+  integrity sha512-gGRkLfCy4pPXOeYuIuls2HMajecaPiUfe20vCHjeTbjVuLkIxNHjqKBqh0LdwEGqenOT1DdFe+h76LWseuqe8Q==
   dependencies:
     "@sentry/node" "^5.15.5"
     "@types/glob" "^7.1.1"
     "@types/puppeteer" "^5.4.0"
     argparse "^1.0.10"
+    axe-core "^4.1.1"
     chokidar "^3.4.2"
     diff "^4.0.2"
     emailjs-imap-client "^3.0.7"


### PR DESCRIPTION
This PR rewrites the handling of source maps so that they are guaranteed to be resolved absolute instead of relative to the file from where it was served from. This fixes issues with vscode's built in debugger functionality where breakpoints weren't hit.