### PR TITLE
Use ESBuild's watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,18 +24,17 @@
 		"dist/"
 	],
 	"dependencies": {
-		"chokidar": "^3.4.3",
 		"karma-sourcemap-loader": "^0.3.8"
 	},
 	"peerDependencies": {
-		"esbuild": "0.8.x"
+		"esbuild": "^0.8.38"
 	},
 	"devDependencies": {
 		"@types/karma": "^5.0.1",
 		"@types/mocha": "^8.2.0",
 		"@types/node": "^14.14.19",
 		"errorstacks": "^2.2.0",
-		"esbuild": "^0.8.29",
+		"esbuild": "^0.8.38",
 		"husky": "^4.3.6",
 		"karma": "^5.2.3",
 		"karma-chrome-launcher": "^3.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import chokidar, { FSWatcher } from "chokidar";
 import { debounce, formatTime } from "./utils";
 import * as karma from "karma";
 import * as esbuild from "esbuild";
@@ -66,6 +65,7 @@ function createPreprocessor(
 		const result = await service!.build({
 			target: "es2015",
 			...userConfig,
+			watch,
 			bundle: true,
 			write: false,
 			entryPoints: files,
@@ -85,29 +85,21 @@ function createPreprocessor(
 
 	const entries = new Set<string>();
 
-	let watcher: FSWatcher | null = null;
 	const watchMode = !config.singleRun && !!config.autoWatch;
-	if (watchMode) {
-		// Initialize watcher to listen for changes in basePath so
-		// that we'll be notified of any new files
-		const basePath = config.basePath || process.cwd();
-		watcher = chokidar.watch([basePath], {
-			ignoreInitial: true,
-			// Ignore dot files and anything from node_modules
-			ignored: /((^|[/\\])\..|node_modules)/,
-		});
-		// Register shutdown handler
-		emitter.on("exit", done => {
-			watcher!.close();
-			done();
-		});
-
-		const onWatch = debounce(async () => {
-			emitter.refreshFiles();
-		}, 100);
-		watcher.on("change", onWatch);
-		watcher.on("add", onWatch);
-	}
+	const onWatchChange = debounce(async () => {
+		emitter.refreshFiles();
+	}, 100);
+	const watch = watchMode
+		? {
+				onRebuild(
+					error: esbuild.BuildFailure | null,
+					result: esbuild.BuildResult | null,
+				) {
+					error && log.error(error.message);
+					result && onWatchChange();
+				},
+		  }
+		: false;
 
 	const afterPreprocess = (time: number) => {
 		logDone(Date.now() - time);

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,7 +424,7 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.4.3, chokidar@^3.4.2, chokidar@^3.4.3:
+chokidar@3.4.3, chokidar@^3.4.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
   integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
@@ -880,10 +880,10 @@ errorstacks@^2.2.0:
   resolved "https://registry.yarnpkg.com/errorstacks/-/errorstacks-2.2.0.tgz#21bdcfc16ded3660c542fc0b286bdf034a126c1a"
   integrity sha512-d/HXKLrpdLYReAnNq5k/KgZKlfc5J+3DKKvci8WKzuM9MAXFrCoCfVyViHk0aFMLyazU/jYhW2d8zTa99pelIA==
 
-esbuild@^0.8.29:
-  version "0.8.29"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.29.tgz#cc20fb752e0905a3546d68ae1be58f9b97044c39"
-  integrity sha512-UDsEoeXuctVgG2hEts1Hwq2jYDGqV7nksEHEZaiCy2v+lXF5ButX4ErPAJAFi5ZNKKW+6Pom93pArV7hki6HnQ==
+esbuild@^0.8.38:
+  version "0.8.39"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.39.tgz#18b84a3d56173c55ee8f45bc6c7b5374b0a98ecb"
+  integrity sha512-/do5H74a5ChyeKRWfkDh3EpICXpsz6dWTtFFbotb7BlIHvWqnRrZYDb8IBubOHdEtKzuiksilRO19aBtp3/HHQ==
 
 escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
- As of ESBuild 0.8.38, ESBuild has native(go implementation) support for watching files.
- Removes chokidar.
- Upped peer + dev dependency to 0.8.38