### PR TITLE
Limit the number of esbuild instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@types/mocha": "^8.2.0",
 		"@types/node": "^14.14.19",
 		"errorstacks": "^2.2.0",
-		"esbuild": "^0.8.38",
+		"esbuild": "^0.8.45",
 		"husky": "^4.3.6",
 		"karma": "^5.2.3",
 		"karma-chrome-launcher": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"karma-sourcemap-loader": "^0.3.8"
 	},
 	"peerDependencies": {
-		"esbuild": "^0.8.38"
+		"esbuild": ">=0.8.45"
 	},
 	"devDependencies": {
 		"@types/karma": "^5.0.1",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,55 @@
+import { SourceMapPayload } from "module";
+
+export interface CacheItem {
+	file: string;
+	content: string;
+	mapFile: string;
+	mapText: SourceMapPayload;
+	mapContent: string;
+	time: number;
+}
+
+export type CacheCb = (item: CacheItem) => void;
+
+export function newCache() {
+	const cache = new Map<string, CacheItem>();
+	const pending = new Map<string, CacheCb[]>();
+	const lastUsed = new Map<string, number>();
+
+	async function set(key: string, item: CacheItem) {
+		cache.set(key, item);
+
+		const waitingFns = pending.get(key);
+		pending.set(key, []);
+		lastUsed.set(key, item.time);
+
+		if (waitingFns) {
+			await Promise.all(waitingFns.map(fn => fn(item)));
+		}
+	}
+
+	async function get(key: string): Promise<CacheItem> {
+		let result = cache.get(key);
+		const last = lastUsed.get(key) || 0;
+		if (result && result.time >= last) {
+			lastUsed.set(key, result.time);
+			return result;
+		}
+
+		return new Promise(resolve => {
+			let fns = pending.get(key) || [];
+			fns.push(resolve);
+			pending.set(key, fns);
+		});
+	}
+
+	function has(key: string) {
+		return cache.has(key) || pending.has(key);
+	}
+
+	return {
+		set,
+		get,
+		has,
+	};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@ errorstacks@^2.2.0:
   resolved "https://registry.yarnpkg.com/errorstacks/-/errorstacks-2.2.0.tgz#21bdcfc16ded3660c542fc0b286bdf034a126c1a"
   integrity sha512-d/HXKLrpdLYReAnNq5k/KgZKlfc5J+3DKKvci8WKzuM9MAXFrCoCfVyViHk0aFMLyazU/jYhW2d8zTa99pelIA==
 
-esbuild@^0.8.38:
-  version "0.8.39"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.39.tgz#18b84a3d56173c55ee8f45bc6c7b5374b0a98ecb"
-  integrity sha512-/do5H74a5ChyeKRWfkDh3EpICXpsz6dWTtFFbotb7BlIHvWqnRrZYDb8IBubOHdEtKzuiksilRO19aBtp3/HHQ==
+esbuild@^0.8.45:
+  version "0.8.45"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.45.tgz#80d57b6b02ed20e05dc0164243b10fc60cf20fc0"
+  integrity sha512-AhR+h/Kat9QMssi0rSJIei0yR+dJ0DQ5aDqnZy4VLu9kOBHdJh8vDSE2XzUlwnm4umvMFnfQTELZlsH7Zmvksw==
 
 escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Turns out that we were spawning more instances of esbuild than necessary, see https://github.com/evanw/esbuild/issues/801#issuecomment-778596066. This was caused by a misunderstanding on our part of the behavioral changes when in watch mode.

The CPU usage is still too high while idling for my taste. We need to investigate if switching back to `chokidar` which uses native FS events instead of a polling mechanism improves that.