### PR TITLE
Reduce idle cpu usage in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"dist/"
 	],
 	"dependencies": {
+		"chokidar": "^3.5.1",
 		"karma-sourcemap-loader": "^0.3.8"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,6 +439,21 @@ chokidar@3.4.3, chokidar@^3.4.2:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -1061,6 +1076,11 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 get-caller-file@^2.0.1:
   version "2.0.5"


### PR DESCRIPTION
This PR reverts back to use chokidar for watching instead of `esbuild`'s built-in watch functionality. The watch mode in `esbuild` is based on polling and hovers around 50% - 60% CPU usage on my
machine (Macbook Air M1 2020) while idling.

<img width="1639" alt="Screenshot 2021-02-13 at 16 05 34" src="https://user-images.githubusercontent.com/1062408/107853408-2ab87680-6e16-11eb-83f6-1f4e0de2aa69.png">

`chokidar` on the other hand uses the OS'es filesystem events and only consumes around 10% CPU usage on the same machine.

<img width="1637" alt="Screenshot 2021-02-13 at 16 06 15" src="https://user-images.githubusercontent.com/1062408/107853411-2e4bfd80-6e16-11eb-8000-b535c414884e.png">

This is a follow up to the performance issues discovered in `karma-esbuild` here https://github.com/evanw/esbuild/issues/801 .