### PR TITLE
Make sure that the file path has the `.js` extension.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,12 @@ function createPreprocessor(
 			if (--count === 0) {
 				afterPreprocess(startTime);
 			}
+			
+			// make sure the file has the `.js` extension
+			if (path.extname(file.path) !== ".js") {
+				file.path = `${file.path.substr(0, file.path .lastIndexOf(".")) || file.path}.js`;
+			}
+			
 			done(null, result.content);
 		} catch (err) {
 			// Use a non-empty string because `karma-sourcemap` crashes


### PR DESCRIPTION
This allows the use of this preprocessor with `jsx` and `ts` files.