### PR TITLE
Do not respond to sourcemaps for unknown files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,9 +210,8 @@ function createSourceMapMiddleware() {
 		const url = (req.url || "").replace(/^\/base\//, "");
 
 		const key = url.replace(/\.map$/, "");
-		// Always resolve from cache directly
-		const item = await cache.get(key);
-		if (item) {
+		if (cache.has(key)) {
+			const item = await cache.get(key);
 			res.setHeader("Content-Type", "application/json");
 			res.end(item.mapContent);
 		} else {

--- a/test/fixtures/sourcemap-fetch/files/main-a.js
+++ b/test/fixtures/sourcemap-fetch/files/main-a.js
@@ -1,0 +1,26 @@
+describe("sourcemap-fetch", () => {
+	async function getMap(selector) {
+		const script = document.querySelector(selector);
+		const url = script.src.replace(/[?#].+/, '') + '.map';
+		const resp = await fetch(url);
+		if (resp.status >= 400) {
+			throw resp.status;
+		}
+		return resp.status;
+	}
+
+	it("should fetch real sourcemap", () => {
+		return getMap('script[src*="main-a.js"]');
+	});
+
+	it("should 404 unknown file", () => {
+		// Mocha is not compiled by esbuild processor.
+		return getMap('script[src*="node_modules/mocha/mocha.js"]').then(() => {
+			throw new Error('expected this to fail');
+		}, (s) => {
+			if (s !== 404) {
+				throw new Error('expected a 404 response');
+			}
+		});
+	});
+});

--- a/test/fixtures/sourcemap-fetch/karma.conf.js
+++ b/test/fixtures/sourcemap-fetch/karma.conf.js
@@ -1,0 +1,10 @@
+const { baseConfig } = require("../../base.karma.conf");
+
+module.exports = function (config) {
+	config.set({
+		...baseConfig,
+		preprocessors: {
+			"**/*.js": ["esbuild", "sourcemap"],
+		},
+	});
+};

--- a/test/sourcemap-fetch.test.ts
+++ b/test/sourcemap-fetch.test.ts
@@ -1,0 +1,15 @@
+import { runKarma } from "./test-utils";
+import { assertEventually } from "pentf/assert_utils";
+import { newPage } from "pentf/browser_utils";
+import path from "path";
+import { strict as assert } from "assert";
+import { SourceMapPayload } from "module";
+
+export const description = "Unknown files are not treated as sourcemaps";
+export async function run(config: any) {
+	const { output } = await runKarma(config, "sourcemap-fetch");
+
+	await assertEventually(() => {
+		return output.stdout.find(line => /2 tests completed/.test(line));
+	});
+}


### PR DESCRIPTION
This is difficult to test for, but when using dev tools to inspect mocha tests, you'll eventually requests sourcemaps. One of those sourcemaps is for `node_modules/mocha/mocha.js.map`. Importantly, `mocha` is a framework, is injected as a separate part of the karma process, and is not bundled by esbuild.

The old sourcemap middleware would catch this request, then wait on esbuild to finally build `mocha.js`. But that's not going to happen, so we end up permanently waiting.