### PR TITLE
Don't store map string to save a bit of memory

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -6,8 +6,7 @@ import { SourceMapPayload } from "module";
 
 interface BundledFile {
 	code: string;
-	parsedMap: SourceMapPayload;
-	map: string;
+	map: SourceMapPayload;
 }
 
 function random(length: number) {
@@ -19,8 +18,7 @@ export class Bundle {
 	private files = new Set<string>();
 	private item: BundledFile = {
 		code: "",
-		parsedMap: {} as SourceMapPayload,
-		map: "",
+		map: {} as SourceMapPayload,
 	};
 	file = path.join(this.dir, `${random(16)}-bundle.js`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,8 +88,7 @@ function createPreprocessor(
 
 		return {
 			code,
-			parsedMap: mapText,
-			map: JSON.stringify(mapText, null, 2),
+			map: mapText,
 		};
 	}
 
@@ -186,8 +185,7 @@ function createPreprocessor(
 
 			bundle.write({
 				code: `console.error(${JSON.stringify(err.message)}`,
-				parsedMap: {} as SourceMapPayload,
-				map: "",
+				map: {} as SourceMapPayload,
 			});
 
 			count = 0;
@@ -205,11 +203,11 @@ function createPreprocessor(
 		const filePath = path.normalize(file.originalPath);
 
 		// If we're "preprocessing" the bundle file, all we need is to wait for
-		// the sourcemap to be generated for it.
+		// the bundle to be generated for it.
 		if (filePath === bundle.file) {
 			await writeBundle.current();
 			const item = bundle.read();
-			file.sourceMap = item.parsedMap;
+			file.sourceMap = item.map;
 			done(null, item.code);
 			return;
 		}
@@ -249,7 +247,7 @@ function createSourcemapMiddleware() {
 
 		const item = bundle.read();
 		res.setHeader("Content-Type", "application/json");
-		res.end(item.map);
+		res.end(JSON.stringify(item.map, null, 2));
 	};
 }
 


### PR DESCRIPTION
Karma requires us to store the parsed map, so we can't eliminate that. But we can eliminate the string format and build it as necessary when serving the map.

This is a small improvement, and only really affects very large projects.