### PR TITLE
Eliminate the test files from the Karma runner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,11 +118,6 @@ function createPreprocessor(
 		watcher.on("add", onWatch);
 	}
 
-	function makeUrl(path: string) {
-		const url = `${config.protocol}//${config.hostname}:${config.port}`;
-		return url + path;
-	}
-
 	async function build(contents: string, file: string) {
 		const userConfig = { ...config.esbuild };
 
@@ -222,8 +217,11 @@ function createPreprocessor(
 		count++;
 
 		bundle.addFile(filePath);
-		await writeBundle();
+		writeBundle();
 
+		// Turn the file into a `dom` type with empty contents to get Karma to
+		// inject the contents as HTML text. Since the contents are empty, it
+		// effectively drops the script from being included into the Karma runner.
 		file.type = "dom";
 		done(null, "");
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ interface KarmaFile {
 	contentPath: string;
 	/** This is a must for mapped stack traces */
 	sourceMap?: SourceMapPayload;
+	type: karma.FilePatternTypes;
 }
 
 type KarmaPreprocess = (
@@ -150,7 +151,7 @@ function createPreprocessor(
 	}
 
 	const beforeProcess = debounce(() => {
-		log.info("Compiling...");
+		log.info(`Compiling to ${bundle.file}...`);
 	}, 10);
 	const afterPreprocess = debounce((time: number) => {
 		log.info(
@@ -223,14 +224,8 @@ function createPreprocessor(
 		bundle.addFile(filePath);
 		await writeBundle();
 
-		const dummy = [
-			`/**`,
-			` * ${filePath}`,
-			` * See ${makeUrl(`/absolute${bundle.file}`)}`,
-			` */`,
-			`(function () {})()`,
-		];
-		done(null, dummy.join("\n"));
+		file.type = "dom";
+		done(null, "");
 	};
 }
 createPreprocessor.$inject = ["config", "emitter", "logger"];


### PR DESCRIPTION
We currently output a useless file for each test, so that Karma won't serve the real JS code in that file. This leads to duplication when debugging with sourcemaps enabled, as we'll see 2 `foo.test.js`s when searching files.

![Screen Shot 2021-03-08 at 7 50 50 PM](https://user-images.githubusercontent.com/112982/110401735-244da100-8048-11eb-81b2-0f7e83e8fd59.png)

Well, Karma has a `type` on the file. Our files are currently `js` type (just means script, doesn't matter if the file is `.ts` or `.jsx`). And if we change the file to a `dom` type then Karma will treat the content as something to inject into the DOM tree. Coupled with an empty contents, make Karma skip the file, and we're left with only the virtual file from the sourcemap.

![Screen Shot 2021-03-08 at 7 54 02 PM](https://user-images.githubusercontent.com/112982/110401753-2b74af00-8048-11eb-8532-2b2ed849ed84.png)