### PR TITLE
Fix bundle output when there's an error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ function createPreprocessor(
 			log.error(err.message);
 
 			bundle.write({
-				code: `console.error(${JSON.stringify(err.message)}`,
+				code: `console.error(${JSON.stringify(err.message)})`,
 				parsedMap: {} as SourceMapPayload,
 				map: "",
 			});

--- a/test/watch-error.test.ts
+++ b/test/watch-error.test.ts
@@ -30,7 +30,7 @@ export async function run(config: any) {
 	await write(`export function;;;123+++++`);
 
 	await assertEventuallyProgresses(output.stdout, () => {
-		return output.stdout.some(line => /Build failed with/.test(line));
+		return output.stdout.some(line => /^Build failed with/.test(line));
 	});
 
 	resetLog();

--- a/test/watch-error.test.ts
+++ b/test/watch-error.test.ts
@@ -30,7 +30,9 @@ export async function run(config: any) {
 	await write(`export function;;;123+++++`);
 
 	await assertEventuallyProgresses(output.stdout, () => {
-		return output.stdout.some(line => /^Build failed with/.test(line));
+		return output.stdout.some(line =>
+			/\[esbuild\]: Build failed with/.test(line),
+		);
 	});
 
 	resetLog();


### PR DESCRIPTION
I missed the trailing `)`, which caused a `SyntaxError`. Funnily, this still logged the error, because the full message is included in thrown `SyntaxError`.