### PR TITLE
Bugfix and minor cleanups

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import * as crypto from "crypto";
+
 export class Deferred<T> {
 	declare promise: Promise<T>;
 	declare resolve: (value: T | PromiseLike<T>) => void;
@@ -9,6 +11,10 @@ export class Deferred<T> {
 			this.reject = reject;
 		});
 	}
+}
+
+export function random(length: number) {
+	return crypto.randomBytes(length).toString("hex");
 }
 
 export function debounce<A extends any[], R>(


### PR DESCRIPTION
- Wait for bundler to stop before calling emitter's `done`.
- Don't debounce `beforeProcess` or `afterProcess` (they're already guarded by `buildBundle`'s debounce and the reentrant design in bundler)