### PR TITLE
Split test entry point from bundler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 import { debounce, formatTime } from "./utils";
 import { Bundle } from "./bundle";
+import { TestEntryPoint } from "./test-entry-point";
 import chokidar from "chokidar";
-import * as karma from "karma";
 import * as path from "path";
 
 import type esbuild from "esbuild";
+import type karma from "karma";
 import type { SourceMapPayload } from "module";
 import type { IncomingMessage, ServerResponse } from "http";
 import type { FSWatcher } from "chokidar";
+import type { Log } from "./utils";
 
 interface KarmaFile {
 	originalPath: string;
@@ -25,27 +27,24 @@ type KarmaPreprocess = (
 ) => void;
 
 interface KarmaLogger {
-	create(label: string): Pick<Console, "info" | "error">;
+	create(label: string): Log;
 }
 
-let bundle: Bundle;
+function getBasePath(config: karma.ConfigOptions) {
+	return config.basePath || process.cwd();
+}
 
 function createPreprocessor(
 	config: karma.ConfigOptions & {
-		esbuild?: esbuild.BuildOptions & { bundleDelay?: number };
+		esbuild?: { bundleDelay?: number };
 	},
 	emitter: karma.Server,
-	logger: KarmaLogger,
+	log: Log,
+	testEntryPoint: TestEntryPoint,
+	bundle: Bundle,
 ): KarmaPreprocess {
-	const log = logger.create("esbuild");
-	const basePath = config.basePath || process.cwd();
-	const { bundleDelay = 700, ...userConfig } = config.esbuild || {};
-
-	// Use some trickery to get the root in both posix and win32. win32 could
-	// have multiple drive paths as root, so find root relative to the basePath.
-	userConfig.outdir = path.resolve(basePath, "/");
-
-	bundle = new Bundle(log, userConfig);
+	const basePath = getBasePath(config);
+	const { bundleDelay = 700 } = config.esbuild || {};
 
 	// Inject middleware to handle the bundled file and map.
 	if (!config.middleware) {
@@ -61,16 +60,16 @@ function createPreprocessor(
 	}
 	// Set preprocessor for our file to install sourceMap on it, giving Karma
 	// the ability do unminify stack traces.
-	config.preprocessors![bundle.file] = ["esbuild"];
+	config.preprocessors![testEntryPoint.file] = ["esbuild"];
 	// For the sourcemapping to work, the file must be served by Karma, preprocessed, and have
 	// the preproccessor attach a file.sourceMap.
 	config.files.push({
-		pattern: bundle.file,
+		pattern: testEntryPoint.file,
 		included: true,
 		served: true,
 		watched: false,
 	});
-	bundle.touch();
+	testEntryPoint.touch();
 
 	let watcher: FSWatcher | null = null;
 	const watchMode = !config.singleRun && !!config.autoWatch;
@@ -80,7 +79,7 @@ function createPreprocessor(
 		watcher = chokidar.watch([basePath], {
 			ignoreInitial: true,
 			// Ignore dot files and anything from node_modules
-			ignored: /((^|[/\\])\..|node_modules)/,
+			ignored: /(^|[/\\])(\.|node_modules[/\\])/,
 		});
 
 		const alreadyWatched = config.files.reduce((watched: string[], file) => {
@@ -112,7 +111,7 @@ function createPreprocessor(
 	let startTime = 0;
 	function beforeProcess() {
 		startTime = Date.now();
-		log.info(`Compiling to ${bundle.file}...`);
+		log.info(`Compiling to ${testEntryPoint.file}...`);
 	}
 	function afterProcess() {
 		log.info(
@@ -131,6 +130,7 @@ function createPreprocessor(
 	const buildBundle = debounce(() => {
 		// Prevent service closed message when we are still processing
 		if (stopped) return;
+		testEntryPoint.write();
 		return bundle.write(beforeProcess, afterProcess);
 	}, bundleDelay);
 
@@ -142,14 +142,14 @@ function createPreprocessor(
 
 		// If we're "preprocessing" the bundle file, all we need is to wait for
 		// the bundle to be generated for it.
-		if (filePath === bundle.file) {
+		if (filePath === testEntryPoint.file) {
 			const item = await bundle.read();
 			file.sourceMap = item.map;
 			done(null, item.code);
 			return;
 		}
 
-		bundle.addFile(filePath);
+		testEntryPoint.addFile(filePath);
 		bundle.dirty();
 		buildBundle();
 
@@ -160,9 +160,18 @@ function createPreprocessor(
 		done(null, "");
 	};
 }
-createPreprocessor.$inject = ["config", "emitter", "logger"];
+createPreprocessor.$inject = [
+	"config",
+	"emitter",
+	"karmaEsbuildLogger",
+	"karmaEsbuildEntryPoint",
+	"karmaEsbuildBundler",
+];
 
-function createSourcemapMiddleware() {
+function createSourcemapMiddleware(
+	testEntryPoint: TestEntryPoint,
+	bundle: Bundle,
+) {
 	return async function (
 		req: IncomingMessage,
 		res: ServerResponse,
@@ -172,15 +181,62 @@ function createSourcemapMiddleware() {
 		if (!match) return next();
 
 		const filePath = path.normalize(match[1]);
-		if (filePath !== bundle.file) return next();
+		if (filePath !== testEntryPoint.file) return next();
 
 		const item = await bundle.read();
 		res.setHeader("Content-Type", "application/json");
 		res.end(JSON.stringify(item.map, null, 2));
 	};
 }
+createSourcemapMiddleware.$inject = [
+	"karmaEsbuildEntryPoint",
+	"karmaEsbuildBundler",
+];
+
+function createEsbuildLog(logger: KarmaLogger) {
+	return logger.create("esbuild");
+}
+createEsbuildLog.$inject = ["logger"];
+
+function createEsbuildConfig(
+	config: karma.ConfigOptions & {
+		esbuild?: esbuild.BuildOptions & { bundleDelay?: number };
+	},
+) {
+	const basePath = getBasePath(config);
+	const { bundleDelay, ...userConfig } = config.esbuild || {};
+
+	// Use some trickery to get the root in both posix and win32. win32 could
+	// have multiple drive paths as root, so find root relative to the basePath.
+	userConfig.outdir = path.resolve(basePath, "/");
+	return userConfig;
+}
+createEsbuildConfig.$inject = ["config"];
+
+function createEsbuildBundler(
+	testEntryPoint: TestEntryPoint,
+	log: Log,
+	config: esbuild.BuildOptions,
+) {
+	return new Bundle(testEntryPoint.file, log, config);
+}
+createEsbuildBundler.$inject = [
+	"karmaEsbuildEntryPoint",
+	"karmaEsbuildLogger",
+	"karmaEsbuildConfig",
+];
+
+function createTestEntryPoint() {
+	return new TestEntryPoint();
+}
+createTestEntryPoint.$inject = [] as const;
 
 module.exports = {
 	"preprocessor:esbuild": ["factory", createPreprocessor],
 	"middleware:esbuild": ["factory", createSourcemapMiddleware],
+
+	karmaEsbuildLogger: ["factory", createEsbuildLog],
+	karmaEsbuildConfig: ["factory", createEsbuildConfig],
+	karmaEsbuildBundler: ["factory", createEsbuildBundler],
+	karmaEsbuildEntryPoint: ["factory", createTestEntryPoint],
 };

--- a/src/test-entry-point.ts
+++ b/src/test-entry-point.ts
@@ -1,0 +1,39 @@
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import { random } from "./utils";
+
+export class TestEntryPoint {
+	// Dirty signifies that new test file has been addeed, and is cleared once the entryPoint is written.
+	private dirty = false;
+	private files = new Set<string>();
+
+	private dir = os.tmpdir();
+	// The `file` is a dummy, meant to allow Karma to work. But, we can't write
+	// to it without causing Karma to refresh. So, we have a real file that we
+	// write to, and allow esbuild to build from.
+	file = path.join(this.dir, `${random(16)}-bundle.js`);
+
+	addFile(file: string) {
+		const normalized = path
+			.relative(this.file, file)
+			.replace(/\\/g, path.posix.sep);
+
+		if (this.files.has(normalized)) return;
+		this.files.add(normalized);
+		this.dirty = true;
+	}
+
+	write() {
+		if (!this.dirty) return;
+		this.dirty = false;
+		const files = Array.from(this.files).map(file => {
+			return `import "${file}";`;
+		});
+		fs.writeFileSync(this.file, files.join("\n"));
+	}
+
+	touch() {
+		fs.writeFileSync(this.file, "");
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
 
+export type Log = Pick<Console, "info" | "error">;
 export class Deferred<T> {
 	declare promise: Promise<T>;
 	declare resolve: (value: T | PromiseLike<T>) => void;


### PR DESCRIPTION
The current code couples together the esbuild bundler (which really only cares about a file existing on disk) and the test "entry point" we generate to import all the user's test files.

This makes reuse of the Bundler difficult. I want to get to the point where we can spin up multiple bundlers. This will eventually allow for something I call "module mode", where esbuild doesn't generate one large super-bundle. Instead, it'll outputs all files as individual ESM modules, and we'll let the browser load each file individually. You can read https://github.com/evanw/esbuild/issues/944 for the full story.