### PR TITLE
Add formatError to unminify stack traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"dist/"
 	],
 	"dependencies": {
-		"chokidar": "^3.5.1"
+		"chokidar": "^3.5.1",
+		"source-map": "0.6.1"
 	},
 	"peerDependencies": {
 		"esbuild": ">=0.8.45"

--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -9,6 +9,11 @@ type Formatter = (m: string) => string;
 export function createFormatError(bundle: Bundle, formatError?: Formatter) {
 	const consumers = new WeakMap<RawSourceMap, SourceMapConsumer>();
 	const regex = /((?:\b[A-Z]:)?\/[^ #?:]+)[^ :]*:(\d+):(\d+)/gi;
+	//             |            |          ||    ||    |^^^^^^ Column
+	//             |            |          ||    |^^^^^^ Line
+	//             |            |          |^^^^^^ Eat any reamining URL (query in particular)
+	//             ^^^^^^^^^^^^^^^^^^^^^^^^^ URL pathname extraction
+	//             ^^^^^^^^^^^^^^ Optionally find a leading win32 disk name (eg, C:)
 
 	function get(sourcemap: RawSourceMap) {
 		const existing = consumers.get(sourcemap);

--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -7,7 +7,7 @@ type Formatter = (m: string) => string;
 
 export function createFormatError(bundle: Bundle, formatError?: Formatter) {
 	const consumers = new WeakMap<RawSourceMap, SourceMapConsumer>();
-	const regex = /(\/[^ #?:]+)[^ :]*:(\d+):(\d+)/g;
+	const regex = /((?:\b[A-Z]:)?\/[^ #?:]+)[^ :]*:(\d+):(\d+)/gi;
 
 	function get(sourcemap: RawSourceMap) {
 		const existing = consumers.get(sourcemap);

--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -1,0 +1,45 @@
+import { SourceMapConsumer } from "source-map";
+
+import type { Bundle } from "./bundle";
+import type { RawSourceMap } from "source-map";
+
+type Formatter = (m: string) => string;
+
+export function createFormatError(bundle: Bundle, formatError?: Formatter) {
+	const consumers = new WeakMap<RawSourceMap, SourceMapConsumer>();
+	const regex = /(\/[^ #?:]+)[^ :]*:(\d+):(\d+)/g;
+
+	function get(sourcemap: RawSourceMap) {
+		const existing = consumers.get(sourcemap);
+		if (existing) return existing;
+		const consumer = new SourceMapConsumer(bundle.sourcemap);
+		consumers.set(sourcemap, consumer);
+		return consumer;
+	}
+
+	function format(file: string, line: number, column: number) {
+		return `${file}:${line}:${column}`;
+	}
+
+	return (message: string) => {
+		const unminified = message.replace(regex, (match, path, line, column) => {
+			if (path !== bundle.file) return match;
+
+			try {
+				const consumer = get(bundle.sourcemap);
+				const loc = consumer.originalPositionFor({
+					line: +line,
+					column: +column - 1,
+				});
+				return `${format(loc.source, loc.line, loc.column + 1)} <- ${format(
+					path,
+					line,
+					column,
+				)}`;
+			} catch {
+				return match;
+			}
+		});
+		return formatError ? formatError(unminified) : unminified + "\n";
+	};
+}

--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -1,4 +1,5 @@
 import { SourceMapConsumer } from "source-map";
+import * as path from "path";
 
 import type { Bundle } from "./bundle";
 import type { RawSourceMap } from "source-map";
@@ -22,8 +23,9 @@ export function createFormatError(bundle: Bundle, formatError?: Formatter) {
 	}
 
 	return (message: string) => {
-		const unminified = message.replace(regex, (match, path, line, column) => {
-			if (path !== bundle.file) return match;
+		const unminified = message.replace(regex, (match, source, line, column) => {
+			source = path.normalize(source);
+			if (source !== bundle.file) return match;
 
 			try {
 				const consumer = get(bundle.sourcemap);
@@ -32,7 +34,7 @@ export function createFormatError(bundle: Bundle, formatError?: Formatter) {
 					column: +column - 1,
 				});
 				return `${format(loc.source, loc.line, loc.column + 1)} <- ${format(
-					path,
+					source,
 					line,
 					column,
 				)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,21 @@
-import { debounce, formatTime } from "./utils";
+import { debounce } from "./utils";
 import { Bundle } from "./bundle";
 import { TestEntryPoint } from "./test-entry-point";
 import chokidar from "chokidar";
 import * as path from "path";
+import { SourceMapConsumer } from "source-map";
 
 import type esbuild from "esbuild";
 import type karma from "karma";
-import type { SourceMapPayload } from "module";
 import type { IncomingMessage, ServerResponse } from "http";
 import type { FSWatcher } from "chokidar";
 import type { Log } from "./utils";
+import { RawSourceMap } from "source-map";
 
 interface KarmaFile {
 	originalPath: string;
 	path: string;
 	contentPath: string;
-	/** This is a must for mapped stack traces */
-	sourceMap?: SourceMapPayload;
 	type: karma.FilePatternTypes;
 }
 
@@ -36,7 +35,7 @@ function getBasePath(config: karma.ConfigOptions) {
 
 function createPreprocessor(
 	config: karma.ConfigOptions & {
-		esbuild?: { bundleDelay?: number };
+		esbuild?: esbuild.BuildOptions & { bundleDelay?: number };
 	},
 	emitter: karma.Server,
 	log: Log,
@@ -47,29 +46,27 @@ function createPreprocessor(
 	const { bundleDelay = 700 } = config.esbuild || {};
 
 	// Inject middleware to handle the bundled file and map.
-	if (!config.middleware) {
-		config.middleware = [];
-	}
+	config.middleware ||= [];
 	config.middleware.push("esbuild");
 
 	// Create an empty file for Karma to track. Karma requires a real file in
 	// order for it to be injected into the page, even though the middleware
 	// will be responsible for serving it.
-	if (!config.files) {
-		config.files = [];
-	}
-	// Set preprocessor for our file to install sourceMap on it, giving Karma
-	// the ability do unminify stack traces.
-	config.preprocessors![testEntryPoint.file] = ["esbuild"];
-	// For the sourcemapping to work, the file must be served by Karma, preprocessed, and have
-	// the preproccessor attach a file.sourceMap.
+	config.files ||= [];
+	// Push the entry point so that Karma will load the file when the runner starts.
 	config.files.push({
 		pattern: testEntryPoint.file,
 		included: true,
-		served: true,
+		served: false,
 		watched: false,
 	});
 	testEntryPoint.touch();
+
+	// Install our own error formatter to provide sourcemap unminification.
+	// Karma's default error reporter will call it, after it does its own
+	// unminification. It'd be awesome if we could just provide the maps for
+	// them to consume, but it's impossibly difficult.
+	config.formatError = createFormatError(bundle, config.formatError);
 
 	let watcher: FSWatcher | null = null;
 	const watchMode = !config.singleRun && !!config.autoWatch;
@@ -108,19 +105,6 @@ function createPreprocessor(
 		watcher.on("add", onWatch);
 	}
 
-	let startTime = 0;
-	function beforeProcess() {
-		startTime = Date.now();
-		log.info(`Compiling to ${testEntryPoint.file}...`);
-	}
-	function afterProcess() {
-		log.info(
-			`Compiling done (${formatTime(Date.now() - startTime)}, with ${formatTime(
-				bundleDelay,
-			)} delay)`,
-		);
-	}
-
 	let stopped = false;
 	emitter.on("exit", done => {
 		stopped = true;
@@ -131,7 +115,7 @@ function createPreprocessor(
 		// Prevent service closed message when we are still processing
 		if (stopped) return;
 		testEntryPoint.write();
-		return bundle.write(beforeProcess, afterProcess);
+		return bundle.write();
 	}, bundleDelay);
 
 	return async function preprocess(content, file, done) {
@@ -140,18 +124,9 @@ function createPreprocessor(
 		// need to test equality.
 		const filePath = path.normalize(file.originalPath);
 
-		// If we're "preprocessing" the bundle file, all we need is to wait for
-		// the bundle to be generated for it.
-		if (filePath === testEntryPoint.file) {
-			const item = await bundle.read();
-			file.sourceMap = item.map;
-			done(null, item.code);
-			return;
-		}
-
 		testEntryPoint.addFile(filePath);
 		bundle.dirty();
-		buildBundle();
+		await buildBundle();
 
 		// Turn the file into a `dom` type with empty contents to get Karma to
 		// inject the contents as HTML text. Since the contents are empty, it
@@ -168,30 +143,71 @@ createPreprocessor.$inject = [
 	"karmaEsbuildBundler",
 ];
 
-function createSourcemapMiddleware(
-	testEntryPoint: TestEntryPoint,
-	bundle: Bundle,
-) {
+function createMiddleware(bundle: Bundle) {
 	return async function (
 		req: IncomingMessage,
 		res: ServerResponse,
 		next: () => void,
 	) {
-		const match = /^\/absolute([^?#]*)\.map(\?|#|$)/.exec(req.url || "");
+		const match = /^\/absolute([^?#]*?)(\.map)?(?:\?|#|$)/.exec(req.url || "");
 		if (!match) return next();
 
 		const filePath = path.normalize(match[1]);
-		if (filePath !== testEntryPoint.file) return next();
+		if (filePath !== bundle.file) return next();
 
 		const item = await bundle.read();
-		res.setHeader("Content-Type", "application/json");
-		res.end(JSON.stringify(item.map, null, 2));
+		if (match[2] === ".map") {
+			res.setHeader("Content-Type", "application/json");
+			res.end(JSON.stringify(item.map, null, 2));
+		} else {
+			res.setHeader("Content-Type", "text/javascript");
+			res.end(item.code);
+		}
 	};
 }
-createSourcemapMiddleware.$inject = [
-	"karmaEsbuildEntryPoint",
-	"karmaEsbuildBundler",
-];
+createMiddleware.$inject = ["karmaEsbuildBundler"];
+
+function createFormatError(
+	bundle: Bundle,
+	formatError?: (m: string) => string,
+) {
+	const consumers = new WeakMap<RawSourceMap, SourceMapConsumer>();
+	const regex = /(\/[^ #?:]+)[^ :]*:(\d+):(\d+)/g;
+
+	function get(sourcemap: RawSourceMap) {
+		const existing = consumers.get(sourcemap);
+		if (existing) return existing;
+		const consumer = new SourceMapConsumer(bundle.sourcemap);
+		consumers.set(sourcemap, consumer);
+		return consumer;
+	}
+
+	function format(file: string, line: number, column: number) {
+		return `${file}:${line}:${column}`;
+	}
+
+	return (message: string) => {
+		const unminified = message.replace(regex, (match, path, line, column) => {
+			if (path !== bundle.file) return match;
+
+			try {
+				const consumer = get(bundle.sourcemap);
+				const loc = consumer.originalPositionFor({
+					line: +line,
+					column: +column - 1,
+				});
+				return `${format(loc.source, loc.line, loc.column + 1)} <- ${format(
+					path,
+					line,
+					column,
+				)}`;
+			} catch {
+				return match;
+			}
+		});
+		return formatError ? formatError(unminified) : unminified + "\n";
+	};
+}
 
 function createEsbuildLog(logger: KarmaLogger) {
 	return logger.create("esbuild");
@@ -233,7 +249,7 @@ createTestEntryPoint.$inject = [] as const;
 
 module.exports = {
 	"preprocessor:esbuild": ["factory", createPreprocessor],
-	"middleware:esbuild": ["factory", createSourcemapMiddleware],
+	"middleware:esbuild": ["factory", createMiddleware],
 
 	karmaEsbuildLogger: ["factory", createEsbuildLog],
 	karmaEsbuildConfig: ["factory", createEsbuildConfig],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,7 +2644,7 @@ source-map-support@^0.5.17:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
While working on module mode, I've realized that it's just impossible to provide individual file modules and hook into Karma's crapy served+preprocessed `file.sourceMap` requirement.

So, this hooks into the `config.formatError` hook that the error reporter uses, and performs the same actions. But now we can populate this formatter with any number of bundles that we're generating.