### PR TITLE
Avoid stringifying compiled contents

### DIFF
--- a/test/fixtures/sourcemap/files/main-a.js
+++ b/test/fixtures/sourcemap/files/main-a.js
@@ -8,7 +8,7 @@ describe("simple", () => {
 		const { pathname } = new URL(script.src);
 		const js = await fetchPolyfill(script.src).then(res => res.text());
 
-		const m = js.match(/\/\/# sourceMappingURL=(.*)$/);
+		const m = js.match(/\/\/# sourceMappingURL=(.*)/);
 		if (!m || m.length < 1) {
 			throw new Error("Unable to find source map url");
 		}


### PR DESCRIPTION
By allowing esbuild to append the external `sourceMappingURL` comment, we can store the output contents as a buffer instead of a forcing its conversion to a string.