### PR TITLE
Make the rebundle test less flakey

### DIFF
--- a/test/fixtures/reentrant-rebundle/karma.conf.js
+++ b/test/fixtures/reentrant-rebundle/karma.conf.js
@@ -3,7 +3,6 @@ const { baseConfig } = require("../../base.karma.conf");
 const path = require("path");
 
 module.exports = function (config) {
-	let setups = 0;
 	config.set({
 		...baseConfig,
 


### PR DESCRIPTION
Sometimes 3 distinct bundle can happen, but only 1 rerun of the test suite. As long as the "no concurrent builds" rule holds, it doesn't matter too much.