### PR TITLE
Set karma to run with type=module when using ESM format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function createPreprocessor(
 	bundle: Bundle,
 ): KarmaPreprocess {
 	const basePath = getBasePath(config);
-	const { bundleDelay = 700 } = config.esbuild || {};
+	const { bundleDelay = 700, format } = config.esbuild || {};
 
 	// Inject middleware to handle the bundled file and map.
 	config.middleware ||= [];
@@ -58,6 +58,7 @@ function createPreprocessor(
 		included: true,
 		served: false,
 		watched: false,
+		type: format === "esm" ? "module" : "js",
 	});
 	testEntryPoint.touch();
 


### PR DESCRIPTION
I can't really test this (jsdom doesn't execute module scripts), but it works.