### PR TITLE
Add flag to create a bundle per test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ module.exports = function (config) {
 				ENABLE_PERFORMANCE: true,
 			},
 			plugins: [createEsbuildPlugin()],
+
+			// Karma-esbuild specific options
+			singleBundle: true, // Merge all test files into one bundle(default: true)
 		},
 	});
 };

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -21,7 +21,7 @@ export class Bundle {
 
 	// Dirty signifies that that the current result is stale, and a new build is
 	// needed. It's reset during the next build.
-	private _dirty = false;
+	private _dirty = true;
 	// buildInProgress tracks the in-progress build. When a build takes too
 	// long, a new build may have been requested before the original completed.
 	// In this case, we resolve that in-progress build with the pending one.
@@ -37,28 +37,18 @@ export class Bundle {
 		this.file = file;
 		this.log = log;
 
-		this.config = {
-			target: "es2015",
-			...config,
-			entryPoints: [file],
-			sourcemap: true,
-			bundle: true,
-			write: false,
-			incremental: true,
-			platform: "browser",
-			define: {
-				"process.env.NODE_ENV": JSON.stringify(
-					process.env.NODE_ENV || "development",
-				),
-				...config.define,
-			},
-		};
+		this.config = { ...config, entryPoints: [file] };
 	}
 
 	dirty() {
 		if (this._dirty) return;
 		this._dirty = true;
 		this.deferred = new Deferred();
+		if (this.buildInProgress) this.write();
+	}
+
+	isDirty() {
+		return this._dirty;
 	}
 
 	async write() {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as esbuild from "esbuild";
-import { EventEmitter } from "events";
+import type { EventEmitter } from "events";
 import { Deferred } from "./utils";
 
 import type { Log } from "./utils";

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -43,7 +43,6 @@ export class Bundle {
 		if (this._dirty) return;
 		this._dirty = true;
 		this.deferred = new Deferred();
-		if (this.buildInProgress) this.write();
 	}
 
 	isDirty() {

--- a/src/bundler-map.ts
+++ b/src/bundler-map.ts
@@ -1,0 +1,53 @@
+import { Bundle } from "./bundle";
+import { Deferred } from "./utils";
+
+import type esbuild from "esbuild";
+import type { Log } from "./utils";
+
+export class BundlerMap {
+	private declare log: Log;
+	private declare config: esbuild.BuildOptions;
+	private potentials = new Set<string>();
+	private bundlers = new Map<string, Bundle>();
+	private _dirty = true;
+	private deferred = new Deferred<void>();
+
+	constructor(log: Log, config: esbuild.BuildOptions) {
+		this.log = log;
+		this.config = config;
+	}
+
+	addPotential(file: string) {
+		if (this.bundlers.has(file)) return;
+		this.potentials.add(file);
+	}
+
+	has(file: string) {
+		return this.bundlers.has(file) || this.potentials.has(file);
+	}
+
+	get(file: string) {
+		let bundler = this.bundlers.get(file);
+		if (!bundler) {
+			bundler = new Bundle(file, this.log, this.config);
+			this.bundlers.set(file, bundler);
+			this.potentials.delete(file);
+		}
+		return bundler;
+	}
+
+	read(file: string) {
+		const bundler = this.get(file);
+		if (bundler.isDirty()) bundler.write();
+		return bundler.read();
+	}
+
+	dirty() {
+		this.bundlers.forEach(b => b.dirty());
+	}
+
+	stop() {
+		const promises = [...this.bundlers.values()].map(b => b.stop());
+		return Promise.all(promises);
+	}
+}

--- a/src/bundler-map.ts
+++ b/src/bundler-map.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import type { EventEmitter } from "events";
 import { Bundle } from "./bundle";
 
 import type esbuild from "esbuild";

--- a/src/bundler-map.ts
+++ b/src/bundler-map.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from "events";
+import { EventEmitter } from "events";
 import { Bundle } from "./bundle";
 
 import type esbuild from "esbuild";

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,8 +181,6 @@ function createPreprocessor(
 			done(null, "");
 		} else {
 			const res = await bundlerMap.read(filePath);
-
-			(file as any).sourceMap = res.map;
 			done(null, res.code);
 		}
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ createPreprocessor.$inject = [
 	"logger",
 ];
 
-function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
+function createMiddleware(bundlerMap: BundlerMap) {
 	return async function (
 		req: IncomingMessage,
 		res: ServerResponse,
@@ -206,13 +206,10 @@ function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 			return next();
 		}
 
-		const type = match[1];
 		const fileUrl = match[2];
 		const isSourceMap = match[3] === ".map";
 
-		const absolutePath =
-			type === "absolute" ? fileUrl : path.join(config.basePath!, fileUrl);
-		const filePath = path.normalize(absolutePath);
+		const filePath = path.normalize(fileUrl);
 		if (!bundlerMap.has(filePath)) return next();
 
 		const item = await bundlerMap.read(filePath);
@@ -225,7 +222,7 @@ function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 		}
 	};
 }
-createMiddleware.$inject = ["karmaEsbuildBundlerMap", "config"];
+createMiddleware.$inject = ["karmaEsbuildBundlerMap"];
 
 function createEsbuildBundlerMap(
 	logger: KarmaLogger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,13 @@ interface KarmaFile {
 	type: karma.FilePatternTypes;
 }
 
+interface KarmaEsbuildConfig {
+	esbuild?: esbuild.BuildOptions & {
+		bundleDelay?: number;
+		singleBundle?: boolean;
+	};
+}
+
 type KarmaPreprocess = (
 	content: any,
 	file: KarmaFile,
@@ -33,9 +40,7 @@ function getBasePath(config: karma.ConfigOptions) {
 }
 
 function createPreprocessor(
-	config: karma.ConfigOptions & {
-		esbuild?: esbuild.BuildOptions & { bundleDelay?: number };
-	},
+	config: karma.ConfigOptions & KarmaEsbuildConfig,
 	emitter: karma.Server,
 	testEntryPoint: TestEntryPoint,
 	bundlerMap: BundlerMap,
@@ -165,9 +170,7 @@ createMiddleware.$inject = ["karmaEsbuildBundlerMap"];
 
 function createEsbuildBundlerMap(
 	logger: KarmaLogger,
-	karmaConfig: karma.ConfigOptions & {
-		esbuild?: esbuild.BuildOptions & { bundleDelay?: number };
-	},
+	karmaConfig: karma.ConfigOptions & KarmaEsbuildConfig,
 ) {
 	const log = logger.create("esbuild");
 	const basePath = getBasePath(karmaConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,8 @@ function createPreprocessor(
 		pendingBundles.add(ev.file);
 	});
 
-	bundlerMap.on("stop", ev => {
-		pendingBundles.delete(ev.file);
+	bundlerMap.on("stop", () => {
+		pendingBundles.clear();
 	});
 
 	bundlerMap.on("done", ev => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ function createPreprocessor(
 		}
 	});
 
-	const buildBundle = debounce(() => {
+	const buildSingleBundle = debounce(() => {
 		// Prevent service closed message when we are still processing
 		if (stopped) return;
 		testEntryPoint.write();
@@ -173,7 +173,7 @@ function createPreprocessor(
 		bundle.dirty();
 
 		if (singleBundle) {
-			await buildBundle();
+			await buildSingleBundle();
 			// Turn the file into a `dom` type with empty contents to get Karma to
 			// inject the contents as HTML text. Since the contents are empty, it
 			// effectively drops the script from being included into the Karma runner.

--- a/test/bundle-per-file-watch.test.ts
+++ b/test/bundle-per-file-watch.test.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { onTeardown } from "pentf/runner";
+import { assertEventuallyProgresses, runKarma } from "./test-utils";
+
+export const description = "Watch separate bundles per test file";
+export async function run(config: any) {
+	const { output, resetLog } = await runKarma(config, "bundle-per-file-watch");
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /2 tests completed/.test(line));
+	});
+
+	const filePath = path.join(
+		__dirname,
+		"fixtures",
+		"bundle-per-file-watch",
+		"files",
+		"dep1.js",
+	);
+
+	const content = await fs.readFile(filePath, "utf-8");
+	const write = (content: string) => fs.writeFile(filePath, content, "utf-8");
+
+	onTeardown(config, async () => {
+		await write(content);
+	});
+
+	resetLog();
+	await write(`export function foo() { return 2 }`);
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /2 tests failed/.test(line));
+	});
+
+	resetLog();
+	await write(content);
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /2 tests completed/.test(line));
+	});
+}

--- a/test/bundle-per-file.test.ts
+++ b/test/bundle-per-file.test.ts
@@ -1,6 +1,4 @@
 import { Config } from "pentf/config";
-import { strict as assert } from "assert";
-import fetch from "node-fetch";
 import { assertEventuallyProgresses, runKarma } from "./test-utils";
 
 export const description = "Create a separate bundle per test file";
@@ -12,31 +10,4 @@ export async function run(config: Config) {
 	await assertEventuallyProgresses(output.stdout, () => {
 		return output.stdout.some(line => /2 tests completed/.test(line));
 	});
-
-	let address;
-	for (const line of output.stdout) {
-		const match = line.match(/(https?:\/\/localhost:\d+)/);
-		if (match) {
-			address = match[1];
-		}
-	}
-
-	// Check that dependency is not inlined
-	let res = await fetch(`${address}/base/files/main-a.js`);
-	let text = await res.text();
-	assert.match(text, /CONTENT/);
-
-	res = await fetch(`${address}/base/files/main-b.js`);
-	text = await res.text();
-	assert.match(text, /CONTENT/);
-
-	// Check that we have no duplicate "compiling..." messages
-	assert.equal(
-		output.stdout.filter(line => /Compiling\.\.\./i.test(line)).length,
-		1,
-	);
-	assert.equal(
-		output.stdout.filter(line => /Compiling done/i.test(line)).length,
-		1,
-	);
 }

--- a/test/bundle-per-file.test.ts
+++ b/test/bundle-per-file.test.ts
@@ -1,0 +1,42 @@
+import { Config } from "pentf/config";
+import { strict as assert } from "assert";
+import fetch from "node-fetch";
+import { assertEventuallyProgresses, runKarma } from "./test-utils";
+
+export const description = "Create a separate bundle per test file";
+export async function run(config: Config) {
+	const { output } = await runKarma(config, "bundle-per-file");
+
+	// Both main-*.js tests are necessary, so that we call the preprocessor twice.
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /2 tests completed/.test(line));
+	});
+
+	let address;
+	for (const line of output.stdout) {
+		const match = line.match(/(https?:\/\/localhost:\d+)/);
+		if (match) {
+			address = match[1];
+		}
+	}
+
+	// Check that dependency is not inlined
+	let res = await fetch(`${address}/base/files/main-a.js`);
+	let text = await res.text();
+	assert.match(text, /CONTENT/);
+
+	res = await fetch(`${address}/base/files/main-b.js`);
+	text = await res.text();
+	assert.match(text, /CONTENT/);
+
+	// Check that we have no duplicate "compiling..." messages
+	assert.equal(
+		output.stdout.filter(line => /Compiling\.\.\./i.test(line)).length,
+		1,
+	);
+	assert.equal(
+		output.stdout.filter(line => /Compiling done/i.test(line)).length,
+		1,
+	);
+}

--- a/test/fixtures/bundle-per-file-watch/files/dep1.js
+++ b/test/fixtures/bundle-per-file-watch/files/dep1.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 42;
+}

--- a/test/fixtures/bundle-per-file-watch/files/main-a.js
+++ b/test/fixtures/bundle-per-file-watch/files/main-a.js
@@ -1,0 +1,9 @@
+import { foo } from "./dep1";
+
+describe("A", () => {
+	it("should work", () => {
+		if (foo() !== 42) {
+			throw new Error("fail");
+		}
+	});
+});

--- a/test/fixtures/bundle-per-file-watch/files/main-b.js
+++ b/test/fixtures/bundle-per-file-watch/files/main-b.js
@@ -1,0 +1,9 @@
+import { foo } from "./dep1";
+
+describe("B", () => {
+	it("should work", () => {
+		if (foo() !== 42) {
+			throw new Error("fail");
+		}
+	});
+});

--- a/test/fixtures/bundle-per-file-watch/karma.conf.js
+++ b/test/fixtures/bundle-per-file-watch/karma.conf.js
@@ -1,0 +1,10 @@
+const { baseConfig } = require("../../base.karma.conf");
+
+module.exports = function (config) {
+	config.set({
+		...baseConfig,
+		esbuild: {
+			singleBundle: false,
+		},
+	});
+};

--- a/test/fixtures/bundle-per-file/files/dep1.js
+++ b/test/fixtures/bundle-per-file/files/dep1.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return "CONTENT";
+}

--- a/test/fixtures/bundle-per-file/files/main-a.js
+++ b/test/fixtures/bundle-per-file/files/main-a.js
@@ -1,0 +1,7 @@
+import { foo } from "./dep1";
+
+describe("Suite A", () => {
+	it("should work", () => {
+		return foo();
+	});
+});

--- a/test/fixtures/bundle-per-file/files/main-b.js
+++ b/test/fixtures/bundle-per-file/files/main-b.js
@@ -1,0 +1,7 @@
+import { foo } from "./dep1";
+
+describe("Suite B", () => {
+	it("should work", () => {
+		return foo();
+	});
+});

--- a/test/fixtures/bundle-per-file/karma.conf.js
+++ b/test/fixtures/bundle-per-file/karma.conf.js
@@ -1,0 +1,10 @@
+const { baseConfig } = require("../../base.karma.conf");
+
+module.exports = function (config) {
+	config.set({
+		...baseConfig,
+		esbuild: {
+			singleBundle: false,
+		},
+	});
+};

--- a/test/reentrant-rebundle.test.ts
+++ b/test/reentrant-rebundle.test.ts
@@ -46,7 +46,6 @@ export async function run(config: any) {
 	});
 
 	const files = output.stdout.join("\n").match(/file: .*/g);
-	console.log(files);
 	assert(files !== null);
 	assert(files.length >= 4);
 	assert.equal(files.length % 4, 0);


### PR DESCRIPTION
This PR brings back an option to control whether we want to bundle all files into a single bundle or create a bundle per file. By setting `singleBundle: false` we'll create a bundle for each test file. The default value is `true`