### PR TITLE
Fix incorrect source map path with relative urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 		const basePath = config.basePath || "";
 		if (
 			basePath &&
-			/^\/base/.test(req.url || "") &&
+			match[1] == "base/" &&
 			!path.isAbsolute(filePath)
 		) {
 			const absolute = path.join(basePath, filePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ interface KarmaLogger {
 }
 
 function getBasePath(config: karma.ConfigOptions) {
-	return config.basePath || process.cwd();
+	return config.basePath ? path.normalize(config.basePath) : process.cwd();
 }
 
 function createPreprocessor(
@@ -47,7 +47,6 @@ function createPreprocessor(
 	logger: KarmaLogger,
 ): KarmaPreprocess {
 	const log = logger.create("esbuild");
-	const basePath = getBasePath(config);
 	const {
 		bundleDelay = 700,
 		format,
@@ -87,6 +86,7 @@ function createPreprocessor(
 	if (watchMode) {
 		// Initialize watcher to listen for changes in basePath so
 		// that we'll be notified of any new files
+		const basePath = getBasePath(config);
 		watcher = chokidar.watch([basePath], {
 			ignoreInitial: true,
 			// Ignore dot files and anything from node_modules
@@ -212,8 +212,8 @@ function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 		const isSourceMap = match[3] === ".map";
 
 		let filePath = path.normalize(fileUrl);
-		const basePath = config.basePath || "";
-		if (basePath && match[1] == "base/") {
+		if (match[1] == "base/") {
+			const basePath = getBasePath(config);
 			const absolute = path.join(basePath, filePath);
 			// Verify that we're in the same basepath if filePath is `../../foo`
 			if (absolute.startsWith(basePath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ createPreprocessor.$inject = [
 	"logger",
 ];
 
-function createMiddleware(bundlerMap: BundlerMap) {
+function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 	return async function (
 		req: IncomingMessage,
 		res: ServerResponse,
@@ -211,7 +211,19 @@ function createMiddleware(bundlerMap: BundlerMap) {
 		const fileUrl = match[2];
 		const isSourceMap = match[3] === ".map";
 
-		const filePath = path.normalize(fileUrl);
+		let filePath = path.normalize(fileUrl);
+		const basePath = config.basePath || "";
+		if (
+			basePath &&
+			/^\/base/.test(req.url || "") &&
+			!path.isAbsolute(filePath)
+		) {
+			const absolute = path.join(basePath, filePath);
+			// Verify that we're in the same basepath if filePath is `../../foo`
+			if (absolute.startsWith(basePath)) {
+				filePath = absolute;
+			}
+		}
 		if (!bundlerMap.has(filePath)) return next();
 
 		const item = await bundlerMap.read(filePath);
@@ -224,7 +236,7 @@ function createMiddleware(bundlerMap: BundlerMap) {
 		}
 	};
 }
-createMiddleware.$inject = ["karmaEsbuildBundlerMap"];
+createMiddleware.$inject = ["karmaEsbuildBundlerMap", "config"];
 
 function createEsbuildBundlerMap(
 	logger: KarmaLogger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,11 +213,7 @@ function createMiddleware(bundlerMap: BundlerMap, config: karma.ConfigOptions) {
 
 		let filePath = path.normalize(fileUrl);
 		const basePath = config.basePath || "";
-		if (
-			basePath &&
-			match[1] == "base/" &&
-			!path.isAbsolute(filePath)
-		) {
+		if (basePath && match[1] == "base/") {
 			const absolute = path.join(basePath, filePath);
 			// Verify that we're in the same basepath if filePath is `../../foo`
 			if (absolute.startsWith(basePath)) {

--- a/test/fixtures/sourcemap-base/files/main-a.js
+++ b/test/fixtures/sourcemap-base/files/main-a.js
@@ -1,0 +1,41 @@
+import { fetchPolyfill } from "../../../fetch-polyfill.js";
+// "env" module is synthetically created by the karma.conf.js using an esbuild plugin.
+import expectedSources from "env";
+
+describe("simple", () => {
+	it("should work", async () => {
+		const script = document.querySelector('script[src*="main-a.js"]');
+		const { pathname } = new URL(script.src);
+		const js = await fetchPolyfill(script.src).then(res => res.text());
+
+		const m = js.match(/\/\/# sourceMappingURL=(.*)/);
+		if (!m || m.length < 1) {
+			throw new Error("Unable to find source map url");
+		}
+
+		const filename = /[^/]+$/.exec(pathname);
+		if (m[1] !== `${filename}.map`) {
+			throw new Error(
+				`unexpected sourceMappingURL value, wanted "${filename}.map" but got "${m[1]}"`,
+			);
+		}
+
+		const mapText = await fetchPolyfill(`${pathname}.map`).then(res =>
+			res.text(),
+		);
+		const sources = JSON.parse(mapText).sources.sort();
+
+		if (sources.length !== expectedSources.length) {
+			throw new Error(
+				`source length differs, wanted ${expectedSources.length} but got ${sources.length}`,
+			);
+		}
+		expectedSources.forEach((expected, i) => {
+			if (sources[i] !== expected) {
+				throw new Error(
+					`source ${i} differs, wanted "${expected}" but got "${sources[i]}"`,
+				);
+			}
+		});
+	});
+});

--- a/test/fixtures/sourcemap-base/files/main-a.js
+++ b/test/fixtures/sourcemap-base/files/main-a.js
@@ -20,9 +20,11 @@ describe("simple", () => {
 			);
 		}
 
+		console.log("FETCH", pathname);
 		const mapText = await fetchPolyfill(`${pathname}.map`).then(res =>
 			res.text(),
 		);
+		console.log("FETCH RESULT", mapText);
 		const sources = JSON.parse(mapText).sources.sort();
 
 		if (sources.length !== expectedSources.length) {

--- a/test/fixtures/sourcemap-base/files/sub/dep2.js
+++ b/test/fixtures/sourcemap-base/files/sub/dep2.js
@@ -1,0 +1,3 @@
+export function bar(a, b) {
+	return a + b;
+}

--- a/test/fixtures/sourcemap-base/files/sub/main-b.js
+++ b/test/fixtures/sourcemap-base/files/sub/main-b.js
@@ -1,0 +1,7 @@
+import { bar } from "./dep2";
+
+describe("simple", () => {
+	it("should work", () => {
+		return bar();
+	});
+});

--- a/test/fixtures/sourcemap-base/karma.conf.js
+++ b/test/fixtures/sourcemap-base/karma.conf.js
@@ -1,0 +1,49 @@
+const { baseConfig } = require("../../base.karma.conf");
+const path = require("path");
+
+const expectedSources = [
+	path.join(process.cwd(), "test", "fetch-polyfill.js"),
+	path.join(
+		process.cwd(),
+		"test",
+		"fixtures",
+		"sourcemap-base",
+		"files",
+		"main-a.js",
+	),
+].sort();
+
+const envPlugin = {
+	name: "env",
+	setup(build) {
+		// Intercept import paths called "env" so esbuild doesn't attempt
+		// to map them to a file system location. Tag them with the "env-ns"
+		// namespace to reserve them for this plugin.
+		build.onResolve({ filter: /^env$/ }, args => ({
+			path: args.path,
+			namespace: "env-ns",
+		}));
+
+		// We're going to hook into esbuild and replace the "env" module loaded
+		// by the tests with our expected results.
+		build.onLoad({ filter: /^env$/, namespace: "env-ns" }, () => ({
+			contents: JSON.stringify(expectedSources),
+			loader: "json",
+		}));
+	},
+};
+
+module.exports = function (config) {
+	console.log(__dirname);
+	config.set({
+		...baseConfig,
+		preprocessors: {
+			"files/**/*.js": ["esbuild"],
+		},
+
+		esbuild: {
+			singleBundle: false,
+			plugins: [envPlugin],
+		},
+	});
+};

--- a/test/sourcemap-base.test.ts
+++ b/test/sourcemap-base.test.ts
@@ -1,0 +1,11 @@
+import { assertEventuallyProgresses, runKarma } from "./test-utils";
+
+export const description =
+	"Resolve source maps from files served via /base url";
+export async function run(config: any) {
+	const { output } = await runKarma(config, "sourcemap-base");
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /2 tests completed/.test(line));
+	});
+}


### PR DESCRIPTION
This PR fixes `404 Errors` when trying to fetch source maps with `singleBundle: false`.

With `singleBundle: false` the test files will typically be resolved to somewhere inside the project directory. When karma detects that, it will use URLs starting with `/base/...` and followed with a relative path to the file. With absolute URLs the full absolute path is used in the URL preceded by `/absolute/...`.

Example project root: `/foo/my-project`

```txt
Absolute: /foo/bar/bob.js -> /absolute/foo/bar/bob.js
Relative: /foo/my-project/bar.js -> /base/bar.js
```

In our internal bundle map structure we're matching files by their absolute path on disk though, which means we need to resolve to the full absolute path when we encounter relative URLs in our middleware.