### PR TITLE
Allow user's esbuild config to override `platform`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,13 +239,13 @@ function createEsbuildBundlerMap(
 
 	const config: esbuild.BuildOptions = {
 		target: "es2015",
+		platform: "browser",
 		...userConfig,
 		outdir,
 		sourcemap: true,
 		bundle: true,
 		write: false,
 		incremental: true,
-		platform: "browser",
 		define: {
 			"process.env.NODE_ENV": JSON.stringify(
 				process.env.NODE_ENV || "development",


### PR DESCRIPTION
This is a simple change that won't be useful for _most_ users of this library. However, I'm trying to use `karma-esbuild` with some tests that run in an Electron app that has full Node.js access within its renderer.

While running Karma tests that're compiled with `karma-esbuild`, I get errors like:

```
ERROR [esbuild]: Build failed with 1 error:
src/helpers/fs.ts:1:40: error: Could not resolve "fs" (use "platform: 'node'" when building for node)
```

This PR lets the user's config override the default `browser` platform. I looked into adding tests for this, but the best way to do it would be to setup a whole Electron config within a fixture, which might be an extra dependency you'd rather not have here for a single line getting moved.

Let me know and I can make it happen! Thanks to everyone that has worked on this library and made it so easy to integrate.