### PR TITLE
Only watch files `esbuild` is configured to build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,14 @@ function createPreprocessor(
 	let watcher: FSWatcher | null = null;
 	const watchMode = !config.singleRun && !!config.autoWatch;
 	if (watchMode) {
-		// Initialize watcher to listen for changes in basePath so
-		// that we'll be notified of any new files
-		watcher = chokidar.watch([basePath], {
+		const watchPaths = Object.entries(config?.preprocessors ?? {})
+			// only inlcude paths that include "esbuild" in the array of preprocessors
+			.filter(([_path, preprocessors]) => preprocessors.includes("esbuild"))
+			.map(([path]) => path);
+
+		// Initialize watcher to listen for changes on paths that have been
+		// configured to be built by esbuild so we'll be notified of any new files
+		watcher = chokidar.watch(watchPaths, {
 			ignoreInitial: true,
 			// Ignore dot files and anything from node_modules
 			ignored: /(^|[/\\])(\.|node_modules[/\\])/,


### PR DESCRIPTION
## What am I trying to accomplish?

This PR adjusts the paths watched via `chokidar` so that `karma-esbuild` only watches paths that are actually configured to be preprocessed by `esbuild`. 

Previously, `chokidar` was watching the entire base path. This can be very slow on large projects, and it may be desirable to avoid watching certain files or directories for whatever reason (in my case certain directories were causing errors).

## What approach did I take?

It would seem the solution would be to constrain what files this watcher is set to watch. I think it would make sense to have it only watch `Object.keys(karmaConfig.preprocessors)` so it would only watch the files that `esbuild` is set to process. To be more precise, I filter `karmaConfig.preprocessors` to include only entries with "esbuild" as the preprocessor.

