### PR TITLE
Unwatch files excluded via Karma `config.exclude`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,8 @@ function createPreprocessor(
 			ignored: /(^|[/\\])(\.|node_modules[/\\])/,
 		});
 
+		if (config?.exclude) watcher.unwatch(config.exclude);
+
 		const alreadyWatched = config.files.reduce((watched: string[], file) => {
 			if (typeof file === "string") {
 				watched.push(file);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ function createPreprocessor(
 			ignored: /(^|[/\\])(\.|node_modules[/\\])/,
 		});
 
-		if (config?.exclude) watcher.unwatch(config.exclude);
+		if (config.exclude) watcher.unwatch(config.exclude);
 
 		const alreadyWatched = config.files.reduce((watched: string[], file) => {
 			if (typeof file === "string") {

--- a/test/fixtures/watch-exclude/files/dep1.js
+++ b/test/fixtures/watch-exclude/files/dep1.js
@@ -1,0 +1,5 @@
+import { excluded } from "./excluded/excluded";
+
+export function foo() {
+	return excluded();
+}

--- a/test/fixtures/watch-exclude/files/excluded/excluded.ts
+++ b/test/fixtures/watch-exclude/files/excluded/excluded.ts
@@ -1,0 +1,3 @@
+export function excluded(): string {
+	return "excluded";
+}

--- a/test/fixtures/watch-exclude/files/excluded/excluded.ts
+++ b/test/fixtures/watch-exclude/files/excluded/excluded.ts
@@ -1,3 +1,3 @@
-export function excluded(): string {
-	return "excluded";
+export function excluded(): number {
+	return 123;
 }

--- a/test/fixtures/watch-exclude/files/main-a.js
+++ b/test/fixtures/watch-exclude/files/main-a.js
@@ -2,7 +2,7 @@ import { foo } from "./dep1";
 
 describe("simple", () => {
 	it("should work", () => {
-		if (foo() !== "excluded") {
+		if (foo() !== 123) {
 			throw new Error("fail: foo() is " + foo());
 		}
 	});

--- a/test/fixtures/watch-exclude/files/main-a.js
+++ b/test/fixtures/watch-exclude/files/main-a.js
@@ -1,0 +1,9 @@
+import { foo } from "./dep1";
+
+describe("simple", () => {
+	it("should work", () => {
+		if (foo() !== "excluded") {
+			throw new Error("fail: foo() is " + foo());
+		}
+	});
+});

--- a/test/fixtures/watch-exclude/karma.conf.js
+++ b/test/fixtures/watch-exclude/karma.conf.js
@@ -1,0 +1,10 @@
+const { promises: fs } = require("fs");
+const { baseConfig } = require("../../base.karma.conf");
+const path = require("path");
+
+module.exports = function (config) {
+	config.set({
+		...baseConfig,
+		exclude: ["files/excluded/*"],
+	});
+};

--- a/test/watch-exclude.test.ts
+++ b/test/watch-exclude.test.ts
@@ -2,10 +2,18 @@ import { assertEventuallyProgresses, runKarma } from "./test-utils";
 import { promises as fs } from "fs";
 import path from "path";
 import { onTeardown } from "pentf/runner";
+import { assertAlways } from "pentf/assert_utils";
 
 export const description = "Respects `exclude` param in karma config";
 export async function run(config: any) {
 	const { output, resetLog } = await runKarma(config, "watch-exclude");
+	// Change excluded file
+	const write = (path: string, content: string) =>
+		fs.writeFile(path, content, "utf-8");
+	onTeardown(config, async () => {
+		await write(excludedPath, fileContent);
+		await write(testPath, testContent);
+	});
 
 	await assertEventuallyProgresses(output.stdout, () => {
 		return output.stdout.some(line => /1 test completed/.test(line));
@@ -27,34 +35,21 @@ export async function run(config: any) {
 		"main-a.js",
 	);
 
-	resetLog();
-
-	// Change excluded file
-	const write = (path: string, content: string) =>
-		fs.writeFile(path, content, "utf-8");
-
 	const fileContent = await fs.readFile(excludedPath, "utf-8");
 	const testContent = await fs.readFile(testPath, "utf-8");
-	const changedContent = fileContent.replace('"excluded"', '"included"');
+	const changedContent = fileContent.replace("123", "321");
 
+	resetLog();
 	await write(excludedPath, changedContent);
 
-	/* uncommenting the following validates that the `exclude` is working as the
-	 * test now fails due to `assertEventuallyProgresses` timing out
-	 */
-	// await assertEventuallyProgresses(output.stdout, () => {
-	// 	return output.stdout.some(line => /1 test failed/.test(line));
-	// });
+	await assertAlways(() => output.stdout.length === 0, {
+		message: `Unexpected compilation output when changing excluded file.`,
+	});
 
 	resetLog();
 	await write(testPath, testContent);
 
 	await assertEventuallyProgresses(output.stdout, () => {
 		return output.stdout.some(line => /1 test failed/.test(line));
-	});
-
-	onTeardown(config, async () => {
-		await write(excludedPath, fileContent);
-		await write(testPath, testContent);
 	});
 }

--- a/test/watch-exclude.test.ts
+++ b/test/watch-exclude.test.ts
@@ -1,0 +1,60 @@
+import { assertEventuallyProgresses, runKarma } from "./test-utils";
+import { promises as fs } from "fs";
+import path from "path";
+import { onTeardown } from "pentf/runner";
+
+export const description = "Respects `exclude` param in karma config";
+export async function run(config: any) {
+	const { output, resetLog } = await runKarma(config, "watch-exclude");
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /1 test completed/.test(line));
+	});
+
+	const excludedPath = path.join(
+		__dirname,
+		"fixtures",
+		"watch-exclude",
+		"files",
+		"excluded",
+		"excluded.ts",
+	);
+	const testPath = path.join(
+		__dirname,
+		"fixtures",
+		"watch-exclude",
+		"files",
+		"main-a.js",
+	);
+
+	resetLog();
+
+	// Change excluded file
+	const write = (path: string, content: string) =>
+		fs.writeFile(path, content, "utf-8");
+
+	const fileContent = await fs.readFile(excludedPath, "utf-8");
+	const testContent = await fs.readFile(testPath, "utf-8");
+	const changedContent = fileContent.replace('"excluded"', '"included"');
+
+	await write(excludedPath, changedContent);
+
+	/* uncommenting the following validates that the `exclude` is working as the
+	 * test now fails due to `assertEventuallyProgresses` timing out
+	 */
+	// await assertEventuallyProgresses(output.stdout, () => {
+	// 	return output.stdout.some(line => /1 test failed/.test(line));
+	// });
+
+	resetLog();
+	await write(testPath, testContent);
+
+	await assertEventuallyProgresses(output.stdout, () => {
+		return output.stdout.some(line => /1 test failed/.test(line));
+	});
+
+	onTeardown(config, async () => {
+		await write(excludedPath, fileContent);
+		await write(testPath, testContent);
+	});
+}


### PR DESCRIPTION
This is an alternate approach to https://github.com/marvinhagemeister/karma-esbuild/pull/41

## What am I trying to accomplish?

This PR adjusts the paths watched via `chokidar` to respect the configured excludes via [karma `config.exclude` directive](http://karma-runner.github.io/6.3/config/configuration-file.html#exclude).

Previously, `chokidar` was watching the entire base path. It may be desirable to avoid watching certain files or directories for whatever reason (in my case certain directories were causing errors).

## What approach did I take?

I added a call to `watcher.unwatch(config.exclude)` immediately after starting the chokidar watcher.