### PR TITLE
Rewrite `.ts` filepaths to `.js` during preprocessing

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -140,10 +140,11 @@ export class Bundle {
 			this.incrementalBuild = result;
 			return this.processResult(result);
 		} catch (err) {
-			this.log.error(err.message);
+			const { message } = err as Error;
+			this.log.error(message);
 
 			return {
-				code: Buffer.from(`console.error(${JSON.stringify(err.message)})`),
+				code: Buffer.from(`console.error(${JSON.stringify(message)})`),
 				map: {} as RawSourceMap,
 			};
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,7 @@ function createPreprocessor(
 			done(null, "");
 		} else {
 			const res = await bundlerMap.read(filePath);
+			file.path = file.originalPath.replace(/\.[^\/]*$/, ".js");
 			done(null, res.code);
 		}
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,10 +159,14 @@ function createPreprocessor(
 	}, bundleDelay);
 
 	return async function preprocess(content, file, done) {
+		// We normalize the file extension to always be '.js', which allows us to
+		// run '.ts' files as test entry-points in a `singleBundle: false` setup.
+		const jsPath = file.originalPath.replace(/\.[^/]+$/, '.js');
+
 		// Karma likes to turn a win32 path (C:\foo\bar) into a posix-like path (C:/foo/bar).
 		// Normally this wouldn't be so bad, but `bundle.file` is a true win32 path, and we
 		// need to test equality.
-		let filePath = path.normalize(file.originalPath);
+		let filePath = path.normalize(jsPath);
 
 		if (singleBundle) {
 			testEntryPoint.addFile(filePath);
@@ -183,7 +187,7 @@ function createPreprocessor(
 			done(null, "");
 		} else {
 			const res = await bundlerMap.read(filePath);
-			file.path = file.originalPath.replace(/\.[^\/]*$/, ".js");
+			file.path = jsPath;
 			done(null, res.code);
 		}
 	};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function debounce<R>(fn: () => R, ms: number) {
 		try {
 			deferred.resolve(fn());
 		} catch (e) {
-			deferred.reject(e);
+			deferred.reject(e as Error);
 		}
 	}
 	return (): Promise<R> => {

--- a/test/fetch-polyfill.js
+++ b/test/fetch-polyfill.js
@@ -6,6 +6,11 @@ export function fetchPolyfill(input) {
 			if (xhr.readyState == /* COMPLETE */ 4) {
 				resolve({
 					status: xhr.status,
+					headers: {
+						get: name => {
+							return xhr.getResponseHeader(name);
+						},
+					},
 					text: () => {
 						return Promise.resolve(xhr.responseText);
 					},

--- a/test/fixtures/sourcemap-base/files/main-a.js
+++ b/test/fixtures/sourcemap-base/files/main-a.js
@@ -20,11 +20,9 @@ describe("simple", () => {
 			);
 		}
 
-		console.log("FETCH", pathname);
 		const mapText = await fetchPolyfill(`${pathname}.map`).then(res =>
 			res.text(),
 		);
-		console.log("FETCH RESULT", mapText);
 		const sources = JSON.parse(mapText).sources.sort();
 
 		if (sources.length !== expectedSources.length) {

--- a/test/fixtures/sourcemap-base/karma.conf.js
+++ b/test/fixtures/sourcemap-base/karma.conf.js
@@ -34,7 +34,6 @@ const envPlugin = {
 };
 
 module.exports = function (config) {
-	console.log(__dirname);
 	config.set({
 		...baseConfig,
 		preprocessors: {

--- a/test/fixtures/sourcemap-fetch/files/main-a.js
+++ b/test/fixtures/sourcemap-fetch/files/main-a.js
@@ -3,7 +3,7 @@ import { fetchPolyfill } from "../../../fetch-polyfill.js";
 describe("sourcemap-fetch", () => {
 	async function getMap(selector) {
 		const script = document.querySelector(selector);
-		const url = script.src.replace(/[?#].+/, "") + ".map";
+		const url = script.src.replace(/[?#].*/, "") + ".map";
 		const resp = await fetchPolyfill(url);
 		if (resp.status >= 400) {
 			throw resp.status;

--- a/test/fixtures/typescript/files/main-a.ts
+++ b/test/fixtures/typescript/files/main-a.ts
@@ -25,4 +25,16 @@ describe("simple", () => {
 			throw new Error(type);
 		}
 	});
+
+	it("should serve .js.map", async () => {
+		const script = document.querySelector('script[src*="main-a.js"]');
+
+		const src = `${script.src.replace(/[?#].*/, '')}.map`;
+		const resp = await fetchPolyfill(src);
+		if (resp.status !== 200) {
+			throw new Error(resp.status);
+		}
+
+		JSON.parse(await resp.text());
+	});
 });

--- a/test/fixtures/typescript/files/main-a.ts
+++ b/test/fixtures/typescript/files/main-a.ts
@@ -1,5 +1,28 @@
+import { fetchPolyfill } from "../../../fetch-polyfill.js";
+
 describe("simple", () => {
 	it("should work", () => {
 		return true;
+	});
+
+	it("should change file extension to .js", () => {
+		const script = document.querySelector('script[src*=".ts"]');
+		if (script) {
+			throw new Error("found .ts script");
+		}
+	});
+
+	it("should serve with correct content-type", async () => {
+		const script = document.querySelector('script[src*="main-a.js"]');
+
+		const resp = await fetchPolyfill(script.src);
+		if (resp.status !== 200) {
+			throw new Error(resp.status);
+		}
+
+		const type = resp.headers.get("content-type");
+		if (!/(text|application)\/javascript/.test(type)) {
+			throw new Error(type);
+		}
 	});
 });

--- a/test/fixtures/typescript/karma.conf.js
+++ b/test/fixtures/typescript/karma.conf.js
@@ -4,5 +4,8 @@ module.exports = function (config) {
 	config.set({
 		...baseConfig,
 		files: [{ pattern: "files/**/*main-*.ts", watched: false, type: "js" }],
+		esbuild: {
+			singleBundle: false,
+		},
 	});
 };

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -6,6 +6,6 @@ export async function run(config: Config) {
 	const { output } = await runKarma(config, "typescript");
 
 	await assertEventuallyProgresses(output.stdout, () => {
-		return output.stdout.some(line => /3 test completed/.test(line));
+		return output.stdout.some(line => /4 tests completed/.test(line));
 	});
 }

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -6,6 +6,6 @@ export async function run(config: Config) {
 	const { output } = await runKarma(config, "typescript");
 
 	await assertEventuallyProgresses(output.stdout, () => {
-		return output.stdout.some(line => /1 test completed/.test(line));
+		return output.stdout.some(line => /3 test completed/.test(line));
 	});
 }


### PR DESCRIPTION
When running in `singleBundle: false` mode, karma will inject a `<script src="…"></script>` for each matched esbuild file, using the normal `base/*` or `absolute/*` URL paths to the file. By overriding the extension used in `file.path`, we make sure that karma will point to a `.js` file and not a `.ts` or `.tsx` file.

Fixes #48