### PR TITLE
Fix urls when filename contains multiple dots.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ function createPreprocessor(
 	return async function preprocess(content, file, done) {
 		// We normalize the file extension to always be '.js', which allows us to
 		// run '.ts' files as test entry-points in a `singleBundle: false` setup.
-		const jsPath = file.originalPath.replace(/\.[^/]+$/, ".js");
+		const jsPath = file.originalPath.replace(/\.[^/.]+$/, ".js");
 
 		// Karma likes to turn a win32 path (C:\foo\bar) into a posix-like path (C:/foo/bar).
 		// Normally this wouldn't be so bad, but `bundle.file` is a true win32 path, and we

--- a/test/fixtures/typescript/files/main-a.foo.ts
+++ b/test/fixtures/typescript/files/main-a.foo.ts
@@ -13,7 +13,7 @@ describe("simple", () => {
 	});
 
 	it("should serve with correct content-type", async () => {
-		const script = document.querySelector('script[src*="main-a.js"]');
+		const script = document.querySelector('script[src*="main-a.foo.js"]');
 
 		const resp = await fetchPolyfill(script.src);
 		if (resp.status !== 200) {
@@ -27,9 +27,9 @@ describe("simple", () => {
 	});
 
 	it("should serve .js.map", async () => {
-		const script = document.querySelector('script[src*="main-a.js"]');
+		const script = document.querySelector('script[src*="main-a.foo.js"]');
 
-		const src = `${script.src.replace(/[?#].*/, '')}.map`;
+		const src = `${script.src.replace(/[?#].*/, "")}.map`;
 		const resp = await fetchPolyfill(src);
 		if (resp.status !== 200) {
 			throw new Error(resp.status);


### PR DESCRIPTION
When a file contains multiple dots like `foo.test.js` we'd treat everything after the first dot as an extension as opposed to everything after the last dot.

This is a regression introduced in #49 which I missed during my review.