### PR TITLE
File paths in entry point bundle should be relative the dir, not the file

### DIFF
--- a/src/test-entry-point.ts
+++ b/src/test-entry-point.ts
@@ -16,7 +16,7 @@ export class TestEntryPoint {
 
 	addFile(file: string) {
 		const normalized = path
-			.relative(this.file, file)
+			.relative(this.dir, file)
 			.replace(/\\/g, path.posix.sep);
 
 		if (this.files.has(normalized)) return;

--- a/src/test-entry-point.ts
+++ b/src/test-entry-point.ts
@@ -8,7 +8,7 @@ export class TestEntryPoint {
 	private dirty = false;
 	private files = new Set<string>();
 
-	private dir = os.tmpdir();
+	private dir = fs.realpathSync(os.tmpdir());
 	// The `file` is a dummy, meant to allow Karma to work. But, we can't write
 	// to it without causing Karma to refresh. So, we have a real file that we
 	// write to, and allow esbuild to build from.


### PR DESCRIPTION
Currently the file paths inserted into the bundle are incorrect since they are relative the entry point file as opposed to the temp dir. This actually works in the common case where the filesystem root is the most common relative folder (the erroneous additional `..` in the path can't walk up from root) but breaks for any other relative folder.

Changing the path to be relative the temp directory as opposed to the entry point file fixes this.